### PR TITLE
Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yaml and/or the recipe/meta.yaml.
 
-language: objective-c
+language: generic
+
+os: osx
 
 env:
   matrix:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Terminology
 Current build status
 ====================
 
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/joblib-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/joblib-feedstock)
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/joblib-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/joblib-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/joblib-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/joblib-feedstock)
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/joblib-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/joblib-feedstock/branch/master)
 
@@ -83,12 +83,17 @@ Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/joblib/bad
 Updating joblib-feedstock
 =========================
 
-If you would like to improve the joblib recipe, please take the normal
-route of forking this repository and submitting a PR. Upon submission, your changes will
-be run on the appropriate platforms to give the reviewer an opportunity to confirm that the
-changes result in a successful build. Once merged, the recipe will be re-built and uploaded
-automatically to the conda-forge channel, whereupon they will be available for everybody to
-install and use.
+If you would like to improve the joblib recipe or build a new
+package version, please fork this repository and submit a PR. Upon submission,
+your changes will be run on the appropriate platforms to give the reviewer an
+opportunity to confirm that the changes result in a successful build. Once
+merged, the recipe will be re-built and uploaded automatically to the
+`conda-forge` channel, whereupon the built conda packages will be available for
+everybody to install and use from the `conda-forge` channel.
+Note that all branches in the conda-forge/joblib-feedstock are
+immediately built and any created packages are uploaded, so PRs should be based
+on branches in forks and branches in the main repository should only be used to
+build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.10.0" %}
+{% set version = "0.10.2" %}
 
 package:
     name: joblib
@@ -6,8 +6,8 @@ package:
 
 source:
     fn: joblib-{{ version }}.tar.gz
-    url: https://pypi.io/packages/source/j/joblib/joblib-{{ version }}.tar.gz
-    sha256: 49b3a0ba956eaa2f077e1ebd230b3c8d7b98afc67520207ada20a4d8b8efd071
+    url: https://github.com/joblib/joblib/archive/{{ version }}.tar.gz
+    sha256: 3c39f6c34b63e7aa7ddbcf72ba1c266ba9ec52f40beca5324753a7934f3aec18
 
 build:
     number: 0


### PR DESCRIPTION
```
Latest changes
===============

Release 0.10.2
--------------

Loïc Estève

    FIX a bug in stack formatting when the error happens in a compiled
    extension. See https://github.com/joblib/joblib/pull/382 for more
    details.

Vincent Latrouite

    FIX a bug in the constructor of BinaryZlibFile that would throw an
    exception when passing unicode filename (Python 2 only).
    See https://github.com/joblib/joblib/pull/384 for more details.

Olivier Grisel

    Expose :class:`joblib.parallel.ParallelBackendBase` and
    :class:`joblib.parallel.AutoBatchingMixin` in the public API to
    make them officially re-usable by backend implementers.
```
