### PR TITLE
MNT: rerender feedstock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,4 @@ install:
 script:
   - conda build ./recipe
 
-after_success:
-
   - ./ci_support/upload_or_check_non_existence.py ./recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 3c39f6c34b63e7aa7ddbcf72ba1c266ba9ec52f40beca5324753a7934f3aec18
 
 build:
-    number: 0
+    number: 1
     script: python setup.py install
 
 requirements:


### PR DESCRIPTION
with conda-smithy 1.2.0

The push failed for some versions of 0.10.2 (OS X only has Python 2.7 right now).
