### PR TITLE
Update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,16 @@ install:
     - cmd: rmdir C:\cygwin /s /q
     - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add a hack to switch to `conda` version `4.1.12` before activating.
+    # This is required to handle a long path activation issue.
+    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: set "PATH=%OLDPATH%"
+    - cmd: set "OLDPATH="
+
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,34 +1,34 @@
-{% set version = "0.10.2" %}
+{% set version = "0.10.3" %}
 
 package:
-    name: joblib
-    version: {{ version }}
+  name: joblib
+  version: {{ version }}
 
 source:
-    fn: joblib-{{ version }}.tar.gz
-    url: https://github.com/joblib/joblib/archive/{{ version }}.tar.gz
-    sha256: 3c39f6c34b63e7aa7ddbcf72ba1c266ba9ec52f40beca5324753a7934f3aec18
+  fn: joblib-{{ version }}.tar.gz
+  url: https://github.com/joblib/joblib/archive/{{ version }}.tar.gz
+  sha256: 2ebbbd4fb466bdb7cb432d9e625846143f45a57633ef94ba87521d58cfdb1377
 
 build:
-    number: 0
-    script: python setup.py install
+  number: 0
+  script: python setup.py install
 
 requirements:
-    build:
-        - python
-    run:
-        - python
+  build:
+    - python
+  run:
+    - python
 
 test:
-    imports:
-        - joblib
+  imports:
+    - joblib
 
 about:
-    home: http://packages.python.org/joblib/
-    license: BSD 3-Clause
-    summary: 'Python function as pipeline jobs.'
+  home: http://packages.python.org/joblib/
+  license: BSD 3-Clause
+  summary: 'Python function as pipeline jobs.'
 
 extra:
-    recipe-maintainers:
-        - ocefpaf
-        - jakirkham
+  recipe-maintainers:
+    - ocefpaf
+    - jakirkham


### PR DESCRIPTION
```
Release 0.10.3
--------------

Loïc Estève

    Fix tests when multiprocessing is disabled via the
    JOBLIB_MULTIPROCESSING environment variable.

harishmk

    Remove warnings in nested Parallel objects when the inner Parallel
    has n_jobs=1. See https://github.com/joblib/joblib/pull/406 for
    more details.
```
